### PR TITLE
Add starting point for supporting provider Descriptive property

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "@iiif/parser": "1.x",
-    "@iiif/presentation-3": "1.x",
-    "@iiif/vault": "0.9.x || 1.x"
+    "@iiif/parser": "1.1.0",
+    "@iiif/presentation-3": "1.1.3",
+    "@iiif/vault": "^0.9.19"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",

--- a/src/base-entity-builder.ts
+++ b/src/base-entity-builder.ts
@@ -10,8 +10,10 @@ import {
   CollectionItemSchemas,
   AnnotationPageNormalized,
   AnnotationPage,
+  ServiceNormalized,
+  ResourceProvider,
 } from '@iiif/presentation-3';
-import { ServiceNormalized } from '@iiif/presentation-3/resources/service';
+
 import { IIIFBuilder } from './iiif-builder';
 
 export class BaseEntityBuilder<
@@ -199,6 +201,15 @@ export class BaseEntityBuilder<
   addThumbnail(resource: ContentResource) {
     this.modified.add('thumbnail');
     this.entity.thumbnail = [...this.entity.thumbnail, this.addEmbeddedInstance(resource, 'ContentResource')];
+  }
+
+  set provider(provider: ResourceProvider[]) {
+    this.addProvider(provider);
+  }
+
+  addProvider(provider: ResourceProvider[]) {
+    this.modified.add('provider');
+    this.entity.provider = [...this.entity.provider, ...provider];
   }
 
   // Technical properties

--- a/yarn.lock
+++ b/yarn.lock
@@ -543,7 +543,7 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@iiif/parser@1.*", "@iiif/parser@1.x":
+"@iiif/parser@1.*":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@iiif/parser/-/parser-1.0.7.tgz#9ffdea2573ec9f1ca40158bd5cd10297dda7df29"
   integrity sha512-AW1922SlL5svf28OowndP9rurM/bKf05AvQw3FnAfIOsh9xNY9UKrkvE8bxToPu3RoC3DozHfHgcvf0UtBaM/Q==
@@ -552,22 +552,43 @@
     "@iiif/presentation-3" "^1.0.4"
     "@types/geojson" "^7946.0.8"
 
+"@iiif/parser@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@iiif/parser/-/parser-1.1.0.tgz#e8d5c1665e8d75a3198abe01fa66e31965b4e48f"
+  integrity sha512-p2pqngR/L+ML+LS8Ah70CTITgW192fmWXxOovSapQnI5rKN6daYrbjl5UuIK9R+n0lFFlJwjW5+tA96E+V39hw==
+  dependencies:
+    "@iiif/presentation-2" "^1.0.4"
+    "@iiif/presentation-3" "^1.1.3"
+    "@types/geojson" "^7946.0.8"
+
 "@iiif/presentation-2@1.*", "@iiif/presentation-2@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@iiif/presentation-2/-/presentation-2-1.0.1.tgz#0d76fedfeac65b31afcc30d9a8dc17f2e57041e4"
   integrity sha512-iWF6rgAi9ksSwbH/4uJW1/49DOL1wN2mLKovu0qy1GYtCTg42bryAxYtnBsw6LrJZWykTStv7R3DynChfECmnA==
 
-"@iiif/presentation-3@1.*", "@iiif/presentation-3@1.x", "@iiif/presentation-3@^1.0.4":
+"@iiif/presentation-2@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@iiif/presentation-2/-/presentation-2-1.0.4.tgz#1664aee995462fdf66ec8dfbae54fc22b4f79c97"
+  integrity sha512-hJakpq62VBajesLJrYPtFm6hcn6c/HkKP7CmKZ5atuzu40m0nifWYsqigR1l9sZGvhhHb/DRshPmiW/0GNrJoA==
+
+"@iiif/presentation-3@1.*", "@iiif/presentation-3@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@iiif/presentation-3/-/presentation-3-1.0.4.tgz#9433c38c6a26e95ef94d1f9e0232962398611d70"
   integrity sha512-L5fPMyNAZ3UaDOR7D4mcv9Z1YJIqx9/nI9kaNcq3azLB4lp5w7cv7O1her3gjIPSH/mLCOuUG5KTBOfE/SgXUg==
   dependencies:
     "@types/geojson" "^7946.0.7"
 
-"@iiif/vault@0.9.x || 1.x":
-  version "0.9.18"
-  resolved "https://registry.yarnpkg.com/@iiif/vault/-/vault-0.9.18.tgz#07d6a90411f45a764635c95908b5b67c873a8384"
-  integrity sha512-714/6X5ZyIuiDGeElUZx1mm8nKFabtxORzfMX7MZyc4IAtASjn1HK68xfTtyolN2cFYDhqFiY3Tz08F7HNIKGQ==
+"@iiif/presentation-3@1.1.3", "@iiif/presentation-3@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@iiif/presentation-3/-/presentation-3-1.1.3.tgz#7f5ea909ae22aa9ce2e9d91cec79f5f1cd0fd6fb"
+  integrity sha512-Ek+25nkQouo0pXAqCsWYbAeS4jLDEBQA7iul2jzgnvoJrucxDQN2lXyNLgOUDRqpTdSqJ69iz5lm6DLaxil+Nw==
+  dependencies:
+    "@types/geojson" "^7946.0.7"
+
+"@iiif/vault@^0.9.19":
+  version "0.9.19"
+  resolved "https://registry.yarnpkg.com/@iiif/vault/-/vault-0.9.19.tgz#e5b6c72e18e8a6e5bf882578cd6b113dff3e3e4d"
+  integrity sha512-YoRp4waV1mGMOJaaTpzn/YnZKRnHZdbXwCt2LbCA89CZhtlTh6QUhs04KWNrGxrxnk/Wtt67/U4SyZgD10g0NQ==
   dependencies:
     "@iiif/parser" "1.*"
     "@iiif/presentation-2" "1.*"


### PR DESCRIPTION
## What does this do?
A starting point for supporting `provider`, and understanding more about `iiif-builder`.  In it's current form, it will support a `provider`'s `MUST` properties, however it does not handle the `SHOULD` or `MAY` properties:

- `homepage`
- `logo`
- `seeAlso`

When investigating this issue, we realized fully supporting the non MUST properties may require digging deeper into `@iiif/parser`, `@iiif/presentation-3`, and / or `@iiif/vault`. 

@stephenwf @mathewjordan  Thoughts on how much work this may require?   (So we can budget time from now til years end).  Thanks!